### PR TITLE
fix(parser): Prevent stripping multiple tags from title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1506,16 +1506,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@jridgewell/source-map": {
-            "version": "0.3.6",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25"
-            }
-        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
             "license": "MIT"
@@ -4066,17 +4056,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/node": {
-            "version": "22.18.8",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
-            "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "undici-types": "~6.21.0"
-            }
-        },
         "node_modules/@types/react": {
             "version": "19.0.10",
             "devOptional": true,
@@ -4718,12 +4697,6 @@
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
-        },
-        "node_modules/buffer-from": {
-            "version": "1.1.2",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/cac": {
             "version": "6.7.14",
@@ -7284,30 +7257,11 @@
                 "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
             }
         },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/source-map-support": {
-            "version": "0.5.21",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
             }
         },
         "node_modules/stackback": {
@@ -7428,30 +7382,6 @@
             "engines": {
                 "node": ">=18"
             }
-        },
-        "node_modules/terser": {
-            "version": "5.39.0",
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.8.2",
-                "commander": "^2.20.0",
-                "source-map-support": "~0.5.20"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/three": {
             "version": "0.175.0",
@@ -7694,14 +7624,6 @@
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
             }
-        },
-        "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/universal-github-app-jwt": {
             "version": "2.2.0",
@@ -8174,18 +8096,6 @@
             "version": "3.1.1",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/yaml": {
-            "version": "2.7.0",
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/src/lib/__tests__/utils-tasks.test.ts
+++ b/src/lib/__tests__/utils-tasks.test.ts
@@ -83,6 +83,24 @@ describe('Task Utilities', () => {
       expect(result.labels).toEqual([]);
       expect(result.projectId).toBeUndefined();
     });
+
+    it('does not strip multiple project tags', () => {
+        const result = parseNaturalLanguage('Task #project1 #project2');
+        expect(result.projectId).toBe('project1');
+        expect(result.title).toBe('Task #project2');
+    });
+
+    it('does not strip multiple assignee tags', () => {
+        const result = parseNaturalLanguage('Task for @john @jane');
+        expect(result.assignee).toBe('john');
+        expect(result.title).toBe('Task for @jane');
+    });
+
+    it('does not strip multiple priority tags', () => {
+        const result = parseNaturalLanguage('Task !p1 !p2');
+        expect(result.priority).toBe(1);
+        expect(result.title).toBe('Task !p2');
+    });
   });
 
   describe('formatDate', () => {

--- a/src/lib/utils-tasks.ts
+++ b/src/lib/utils-tasks.ts
@@ -14,28 +14,28 @@ export function parseNaturalLanguage(input: string): ParsedTask {
   const projectMatch = input.match(/#(\w+)/);
   if (projectMatch) {
     result.projectId = projectMatch[1];
-    result.title = result.title.replace(/#\w+/g, '').trim();
+    result.title = result.title.replace(/#\w+/, '').replace(/\s\s+/g, ' ').trim();
   }
 
   // Parse labels (+label)
   const labelMatches = input.match(/\+(\w+)/g);
   if (labelMatches) {
     result.labels = labelMatches.map(label => label.slice(1));
-    result.title = result.title.replace(/\+\w+/g, '').trim();
+    result.title = result.title.replace(/\+\w+/g, '').replace(/\s\s+/g, ' ').trim();
   }
 
   // Parse priority (!p1, !p2, !p3, !p4)
   const priorityMatch = input.match(/!p([1-4])/);
   if (priorityMatch) {
     result.priority = parseInt(priorityMatch[1]) as 1 | 2 | 3 | 4;
-    result.title = result.title.replace(/!p[1-4]/g, '').trim();
+    result.title = result.title.replace(/!p[1-4]/, '').replace(/\s\s+/g, ' ').trim();
   }
 
   // Parse assignee (@user)
   const assigneeMatch = input.match(/@(\w+)/);
   if (assigneeMatch) {
     result.assignee = assigneeMatch[1];
-    result.title = result.title.replace(/@\w+/g, '').trim();
+    result.title = result.title.replace(/@\w+/, '').replace(/\s\s+/g, ' ').trim();
   }
 
   // Parse dates (basic implementation)


### PR DESCRIPTION
The natural language parser was incorrectly removing all occurrences of a pattern (e.g., #project, @user) from the task title, even when only the first one was being processed. This resulted in the silent loss of data if a user included multiple similar tags in a task title.

This commit fixes the issue by removing the global flag (`g`) from the regular expression used in the `replace` method. This ensures that only the first matched instance is removed, preserving any subsequent tags in the title. Additionally, it cleans up any extra whitespace that may result from the replacement.